### PR TITLE
Make SVCB parameter "oblivious-gateway"

### DIFF
--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -37,7 +37,7 @@ informative:
 This document defines a parameter that can be included in SVCB and HTTPS
 DNS resource records to denote that a service is accessible using Oblivious
 HTTP, with an indication of which Oblivious Gateway Resource to use to access
-the service (aa an Oblivious Target Resource). This document also defines
+the service (as an Oblivious Target Resource). This document also defines
 mechanisms to learn more details about the related Oblivious Gateway Resource,
 such as its key configuration.
 
@@ -70,7 +70,7 @@ The presence of this parameter indicates that a service can act as an oblivious
 target, and indicates an oblivious gateway that can provide access to the target.
 
 This document also defines two well-known URIs {{!RFC8615}}, which
-are access on the oblivious gateway indicated in the SVCB record.
+are accessed on the oblivious gateway indicated in the SVCB record.
 
 - "oblivious-configs", which can be used to look up key configurations
 on a host that has been identified as an oblivious gateway using SVCB
@@ -81,7 +81,7 @@ to a host that has been identified as an oblivious gateway using SVCB
 records ({{well-known-gateway}}).
 
 This mechanism does not aid in the discovery of oblivious relays;
-the configuration of relays is out of scope for this document.
+relay configuration is out of scope for this document.
 
 # Conventions and Definitions
 
@@ -273,7 +273,7 @@ svc.example.com. 7200  IN HTTPS 1 . (
 
 would be "https://osvc.example.com/.well-known/oblivious-gateway".
 
-Request to this resource are expected to use the content type
+Requests to this resource are expected to use the content type
 "message/ohttp-req", and responses are expected to use "message/ohttp-res",
 as defined in {{OHTTP}}.
 

--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -173,7 +173,7 @@ _dns.resolver.arpa  7200  IN SVCB 1 doh.example.net (
 Clients still need to perform some verification of oblivious DNS servers,
 such as the TLS certificate check described in {{DDR}}. This certificate
 check can be done when looking up the configuration on the resolver
-using the well-known URI ({{well-known}}), which can either be done
+using the well-known URI ({{well-known-config}}), which can either be done
 directly, or via a proxy to avoid exposing client IP addresses.
 
 Clients also need to ensure that they are not being targeted with unique

--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -65,7 +65,7 @@ and HTTPS DNS resource records {{!SVCB=I-D.draft-ietf-dnsop-svcb-https}}.
 The presence of this parameter indicates that a service can act as an oblivious
 gateway; see {{Section 2 of OHTTP}} for a description of oblivious gateway.
 
-This document also defines two well-known URIs {{!RFC8615}}: 
+This document also defines two well-known URIs {{!RFC8615}}:
 
 - "oblivious-configs", which can be used to look up key configurations
 on a host that has been identified as an oblivious gateway using SVCB


### PR DESCRIPTION
Closes #16
Closes #17

This is a reconstruction of the discovery that changes from a boolean, to a name of the oblivious gateway.

The theory here is that if you're looking up records for a target you're trying to talk to, and looking up HTTPS records (for normal HTTP resources) or SVCB records (for DoH servers), you can get a parameter back indicating that there's an oblivious gateway that is designed specifically to work with this target. This parameter contains the URI of the oblivious gateway server.

Of course, the oblivious gateway _can_ be co-located with the target resource, but they don't need to be. This was a bug in the previous approach to not allow them to be different.

Once you know this, you still need to know the configuration to use on the client to create the request. This is done by issuing a GET to the gateway resource.