### PR TITLE
Bind the gateway to the target

### DIFF
--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -305,16 +305,16 @@ registry ({{SVCB}}).
 
 ## Well-Known URI
 
- IANA is requested to add one new entry in the "Well-Known URIs" registry {{WELLKNOWN}}.
- 
- URI suffix: oblivious-gateway
+IANA is requested to add one new entry in the "Well-Known URIs" registry {{WELLKNOWN}}.
 
- Change controller: IETF
+URI suffix: oblivious-gateway
 
- Specification document: This document
+Change controller: IETF
 
- Status: permanent
+Specification document: This document
 
- Related information: N/A
+Status: permanent
+
+Related information: N/A
 
 --- back

--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -59,7 +59,7 @@ shared in a bespoke fashion. However, some deployments involve clients
 discovering oblivious targets and their assoicated gateways more dynamically.
 For example, a network may want to advertise a DNS resolver that is accessible
 over Oblivious HTTP and applies local network resolution policies via mechanisms
-like Discovery of Designated Resolvers ({{!DDR=I-D.draft-ietf-add-ddr}}. Clients
+like Discovery of Designated Resolvers ({{!DDR=I-D.draft-ietf-add-ddr}}). Clients
 can work with trusted relays to access these gateways.
 
 This document defines a mechanism to advertise that an HTTP service supports

--- a/draft-pauly-ohai-svcb-config.md
+++ b/draft-pauly-ohai-svcb-config.md
@@ -217,7 +217,7 @@ Clients also need to know the key configuration of an oblivious gateway before
 sending oblivious requests.
 
 In order to fetch the key configuration of an oblivious gateway discovered
-in the manner described in {{gateway-fetch}}, the client issues a GET request
+in the manner described in {{gateway-location}}, the client issues a GET request
 to the URI of the gateway specifying the "application/ohttp-keys" ({{OHTTP}})
 media type in the Accept header.
 


### PR DESCRIPTION
Closes #23

- Move the SVCB parameter back to a boolean
- Define a well-known off of the target for the gateway location, which can redirect to a more specific URI
- Still fetch the config from the gateway itself