### PR TITLE
Update gateway config fetch example to use well-known

### DIFF
--- a/draft-ietf-ohai-svcb-config.md
+++ b/draft-ietf-ohai-svcb-config.md
@@ -248,12 +248,12 @@ to the URI of the gateway specifying the "application/ohttp-keys" ({{OHTTP}})
 media type in the Accept header.
 
 For example, if the client knows an oblivious gateway URI,
-"https://osvc.example.com/.well-known/oblivious-gateway", it could fetch the
+"https://svc.example.com/.well-known/oblivious-gateway", it could fetch the
 key configuration with the following request:
 
 ~~~
 GET /.well-known/oblivious-gateway HTTP/1.1
-Host: osvc.example.com
+Host: svc.example.com
 Accept: application/ohttp-keys
 ~~~
 

--- a/draft-ietf-ohai-svcb-config.md
+++ b/draft-ietf-ohai-svcb-config.md
@@ -248,11 +248,11 @@ to the URI of the gateway specifying the "application/ohttp-keys" ({{OHTTP}})
 media type in the Accept header.
 
 For example, if the client knows an oblivious gateway URI,
-"https://osvc.example.com/gateway", it could fetch the key configuration
-with the following request:
+"https://osvc.example.com/.well-known/oblivious-gateway", it could fetch the
+key configuration with the following request:
 
 ~~~
-GET /gateway HTTP/1.1
+GET /.well-known/oblivious-gateway HTTP/1.1
 Host: osvc.example.com
 Accept: application/ohttp-keys
 ~~~


### PR DESCRIPTION
Since in the discovery case, clients will generally use the well-known, that should be in the example